### PR TITLE
docs: DTO migration blueprint for Product, ProductCategory and Story front flows

### DIFF
--- a/EImece/conversionDto.txt
+++ b/EImece/conversionDto.txt
@@ -1,108 +1,292 @@
+DTO Refactoring Blueprint (Product -> ProductCategory -> BlogPost/Story)
+====================================================================
 
+1) ProductDetailViewModel (changed properties only)
+---------------------------------------------------
+Before:
+public Product Product { get; set; }
+public ProductComment ProductComment { get; set; }
+public Menu ProductMenu { get; set; }
+public Menu MainPageMenu { get; set; }
+public Template Template { get; set; }
+public List<Story> RelatedStories { get; set; }
+public List<Product> RelatedProducts { get; set; }
+public Setting CargoDescription { get; set; }
+public Setting CargoPrice { get; set; }
+public Setting IsProductPriceEnable { get; set; }
+public Setting IsProductReviewEnable { get; set; }
+public Setting WhatsAppCommunicationLink { get; set; }
+public Setting CompanyName { get; set; }
 
- 
-I realized that I was using entity classes in whole project razor pages instead of DTO objects,  I need to change them all, so use DTO objects for each entity and convert them in service layer class and just use DTO objects in razor pages, conversion from entity to DTO should be in the service layer, DTO will be used in Razor pages
+After:
+public ProductDto ProductDto { get; set; }
+public ProductCommentDto ProductCommentDto { get; set; }
+public MenuDto ProductMenuDto { get; set; }
+public MenuDto MainPageMenuDto { get; set; }
+public TemplateDto TemplateDto { get; set; }
+public List<StoryDto> RelatedStoriesDto { get; set; }
+public List<ProductDto> RelatedProductsDto { get; set; }
+public SettingDto CargoDescriptionDto { get; set; }
+public SettingDto CargoPriceDto { get; set; }
+public SettingDto IsProductPriceEnableDto { get; set; }
+public SettingDto IsProductReviewEnableDto { get; set; }
+public SettingDto WhatsAppCommunicationLinkDto { get; set; }
+public SettingDto CompanyNameDto { get; set; }
 
-use dto objects for all razor pages, any views file under root folder
- of end users, not admin pages but end users
-
-DO NOT CREATE EImece.Domain.Models.FrontModels CLASSES, USE EXISTING EImece.Domain.Models.FrontModels CLASSES\nCONVERSION TO DTOs in FrontEnd Models SHOULD BE DONE for ALL pages and Services\nin the Services layer, keep existing methods as they are and create new methods for only conversion to DTOs for EImece.Domain.Models.FrontModels CLASSES and its fields \nUse new methods of Service layer generating EImece.Domain.Models.FrontModels CLASSES with DTOs for controller layer of just end user controllers, not admin controller classes\n\nIF IT IS ENTITY, USE ITS DTO CONVERSION, IF IT IS NOT ENTITY, JUST KEEP IT IS\n\n\nIn the project, Razor Pages currently use entity classes located in:\n\n\EImece.Domain\Models\FrontModels\n\n\nThis is incorrect design — UI should not depend on persistence entities.\nTherefore, all Razor Pages must use DTO objects instead of entity classes.\n\nI created DTO models under:\n\n\EImece.Domain\Models\DTOs\n\n\nMy objective is to refactor the application so every model inside FrontModels becomes a UI/ViewModel that is built from DTOs (not entities).\n\nAs a first example, I migrated ProductCategory:\n\npublic ActionResult GetProductCategoryDto(string id)\n{\n    var productCategory = ProductCategoryService.GetProductCategoryDto(id.GetId());\n    return View(productCategory);\n}\n\n\nService:\n use Mapper object to convert entity to DTOs in service layer, below one example\n   var result = Mapper.Map<ProductCategoryDto>(productCategory);\npublic ProductCategoryDto GetProductCategoryDto(int productCategoryId)\n{\n    var productCategory = GetProductCategory(productCategoryId);\n    var result = Mapper.Map<ProductCategoryDto>(productCategory);\n    return result;\n}\n\n\nThe Razor page now consumes ProductCategoryDto instead of the entity.\n\nHowever, most models inside:\n\n\EImece.Domain\Models\FrontModels\n\n\nare much more complex and contain nested relations and aggregated data.\n\nI need a scalable refactoring strategy so that:\n\nEvery Razor Page uses DTO-based models\n\nFrontModels become ViewModels composed from DTOs\n\nMapping logic stays centralized\n\nThe application behavior does not break during migration\n\n
-
-------------------
-
-You are an expert .NET refactoring architect.
-Project Context
-
-This is an ASP.NET Core Razor Pages application.
-Entity classes live in the domain layer (mostly under EImece.Domain.Models.Entities.* and similar).
-There is a folder EImece.Domain\Models\FrontModels that contains complex ViewModel-style classes used by all end-user Razor Pages (not admin pages).
-These FrontModels classes currently contain entity classes directly (sometimes deeply nested) → this is the anti-pattern we are fixing.
-We have already created clean DTOs in EImece.Domain\Models\DTOs for every relevant entity (e.g. ProductCategoryDto, ProductDto, BlogPostDto, etc.).
-
-Strict Requirements
-
-Do NOT create any new classes in EImece.Domain.Models.FrontModels.
-→ Use the existingFrontModels classes and refactor them to use DTOs instead of entities.
-FrontModels become pure ViewModels composed only of:
-DTOs (for anything that was previously an entity)
-Primitive types, enums, simple collections, etc. (keep these unchanged)
-
-Rule for properties:
-If a property is (or contains) an Entity → replace it with its corresponding DTO.
-If a property is not an entity (string, int, bool, List<string>, etc.) → leave it exactly as it is.
-
-Service Layer Rules (very important)
-Never touch existing public methods (they must continue to return entities for admin side and backward compatibility).
-Create new methods with the suffix ForFront (or Dto when it returns a single DTO) that return FrontModels populated with DTOs.
-All mapping logic must happen only in the service layer using AutoMapper (_mapper.Map<...>(...)).
-Example naming:C#// Existing (keep)
-ProductCategory GetProductCategory(int id);
-
-// New
-ProductCategoryFront GetProductCategoryForFront(string id);        // returns FrontModel with DTOs
-ProductCategoryDto GetProductCategoryDto(int id);                 // simple DTO version
-
-Controller / Razor Pages (End-User Only)
-Only end-user controllers (and their Razor Pages under the root) should use the new ForFront / DTO methods.
-Admin controllers stay unchanged (they can continue using entities).
-Every Razor Page that currently receives a FrontModel containing entities must now receive the same FrontModel but with DTOs inside.
-
-Mapping Strategy (Centralized)
-Use AutoMapper profiles (create/update them in the DTO mapping profile).
-For complex nested FrontModels, the service method should:
-Call existing entity-returning methods.
-Map every entity → DTO using AutoMapper.
-Construct and return the FrontModel with the DTOs injected.
-
-
-
-Task
-Refactor the entire end-user layer (all Razor Pages + their controllers + services) according to the rules above.
-Start with the most used FrontModels first (ProductCategoryFront, ProductFront, BlogPostFront, etc.), then continue with the rest.
-For each change, show:
-
-The new service method (or updated one)
-The refactored FrontModel class (only the changed properties)
-The updated controller action
-The AutoMapper mapping needed (if new)
-
-Begin now.
-
--------------------------
-
-The Fixed Prompt
-Role: You are a Senior .NET Architect specializing in Clean Architecture and Refactoring.
-
-Objective:
-Refactor the EImece project to decouple the UI (Razor Pages) from Domain Entities. All Razor Pages must consume DTOs or ViewModels composed of DTOs. Persistence entities must never reach the Controller or View.
-
-Constraints:
-
-FrontModels (UI Models): DO NOT create new classes in EImece.Domain.Models.FrontModels. Use the existing ones, but update their properties to use DTOs instead of Entities.
-
-DTO Location: All DTOs are located in EImece.Domain.Models.DTOs.
-
-Service Layer: Keep existing methods that return Entities. Add new methods specifically for DTO conversion (e.g., Get[Entity]Dto).
-
-Mapping: Use the Mapper (AutoMapper) object inside the Service layer to perform the conversion.
-
-Scope: Focus strictly on End-User controllers and Razor pages. Do not modify Admin controllers or pages.
-
-Logic: If a property is a Domain Entity, replace it with its corresponding DTO. If it is a primitive or non-entity, leave it as is.
-
-Refactoring Pattern to Follow:
-
-Service Layer Change:
-
-C#
-// Existing method stays for internal/admin use
-public ProductCategory GetProductCategory(int id) { ... }
-
-// NEW method for FrontEnd
-public ProductCategoryDto GetProductCategoryDto(int id)
+2) New ProductService method
+----------------------------
+public ProductDetailViewModel GetProductDetailForFrontById(int id)
 {
-    var entity = GetProductCategory(id);
-    return Mapper.Map<ProductCategoryDto>(entity);
+    var product = GetProductById(id); // existing entity-returning method
+    if (product == null) return null;
+
+    var language = product.Lang;
+    var productTags = product.ProductTags?.Select(t => t.Tag).ToList() ?? new List<Tag>();
+    var relatedStories = productTags.Any()
+        ? StoryRepository.GetRelatedStories(productTags.Select(t => t.Id).ToArray(), 10, language, 0)
+        : new List<Story>();
+
+    var relatedProducts = productTags.Any()
+        ? ProductRepository.GetRelatedProducts(productTags.Select(t => t.Id).ToArray(), 10, language, product.Id)
+        : new List<Product>();
+
+    return new ProductDetailViewModel
+    {
+        ProductDto = _mapper.Map<ProductDto>(product),
+        ProductCommentDto = new ProductCommentDto { ProductId = product.Id },
+        ProductMenuDto = _mapper.Map<MenuDto>(MenuService.GetActiveBaseContentsFromCache(true, language)
+            .FirstOrDefault(r => r.MenuLink.Equals("products-index", StringComparison.InvariantCultureIgnoreCase))),
+        MainPageMenuDto = _mapper.Map<MenuDto>(MenuService.GetActiveBaseContentsFromCache(true, language)
+            .FirstOrDefault(r => r.MenuLink.Equals("home-index", StringComparison.InvariantCultureIgnoreCase))),
+        TemplateDto = product.ProductCategory?.Template != null ? _mapper.Map<TemplateDto>(product.ProductCategory.Template) : null,
+        RelatedStoriesDto = _mapper.Map<List<StoryDto>>(relatedStories),
+        RelatedProductsDto = _mapper.Map<List<ProductDto>>(relatedProducts),
+        CargoDescriptionDto = _mapper.Map<SettingDto>(SettingService.GetSettingObjectByKey(Constants.CargoDescription)),
+        CargoPriceDto = _mapper.Map<SettingDto>(SettingService.GetSettingObjectByKey(Constants.CargoPrice)),
+        IsProductPriceEnableDto = _mapper.Map<SettingDto>(SettingService.GetSettingObjectByKey(Constants.IsProductPriceEnable)),
+        IsProductReviewEnableDto = _mapper.Map<SettingDto>(SettingService.GetSettingObjectByKey(Constants.IsProductReviewEnable)),
+        WhatsAppCommunicationLinkDto = _mapper.Map<SettingDto>(SettingService.GetSettingObjectByKey(Constants.WhatsAppCommunicationLink)),
+        CompanyNameDto = _mapper.Map<SettingDto>(SettingService.GetSettingObjectByKey(Constants.CompanyName))
+    };
 }
-Controller Layer Change:
-Update End-User controllers to call the new DTO-based service methods and pass the DTO/FrontModel to the View.
+
+3) Updated End-User Controller example
+--------------------------------------
+public ActionResult Detail(string id, int page = 1)
+{
+    var productId = id.GetId();
+    var vm = ProductService.GetProductDetailForFrontById(productId);
+    if (vm == null || vm.ProductDto == null || !vm.ProductDto.IsActive)
+    {
+        return RedirectToAction("NotFound", "Error");
+    }
+
+    vm.Page = page;
+    vm.RecordPerPage = AppConfig.ProductCommentsRecordPerPage;
+    vm.SeoId = id;
+
+    return View(vm);
+}
+
+4) Minimal .cshtml illustration
+-------------------------------
+@model EImece.Domain.Models.FrontModels.ProductDetailViewModel
+<h1>@Model.ProductDto.ProductNameStr</h1>
+
+5) AutoMapper mappings
+----------------------
+// already in MappingProfile for most entities, add only if missing:
+CreateMap<ProductComment, ProductCommentDto>();
+CreateMap<Template, TemplateDto>();
+
+
+1) ProductCategoryViewModel (changed properties only)
+-----------------------------------------------------
+Before:
+public ProductCategory ProductCategory { get; set; }
+public List<Product> CategoryChildrenProducts { get; set; }
+public Menu ProductMenu { get; set; }
+public Menu MainPageMenu { get; set; }
+public List<ProductCategory> ChildrenProductCategories { get; set; }
+public List<Brand> Brands { get; set; }
+public Setting PriceFilterSetting { get; set; }
+public List<Product> AllProducts { get; set; }
+
+After:
+public ProductCategoryDto ProductCategoryDto { get; set; }
+public List<ProductDto> CategoryChildrenProductsDto { get; set; }
+public MenuDto ProductMenuDto { get; set; }
+public MenuDto MainPageMenuDto { get; set; }
+public List<ProductCategoryDto> ChildrenProductCategoriesDto { get; set; }
+public List<BrandDto> BrandsDto { get; set; }
+public SettingDto PriceFilterSettingDto { get; set; }
+public List<ProductDto> AllProductsDto { get; set; }
+
+2) New ProductCategoryService method
+------------------------------------
+public ProductCategoryViewModel GetProductCategoryForFront(int productCategoryId)
+{
+    var category = GetProductCategory(productCategoryId);
+    if (category == null) return null;
+
+    if (category.ParentId > 0)
+    {
+        category.Parent = GetProductCategory(category.ParentId);
+        if (category.Parent?.ParentId > 0)
+        {
+            category.Parent.Parent = GetProductCategory(category.Parent.ParentId);
+        }
+    }
+
+    var lang = category.Lang;
+    var menus = MenuService.GetActiveBaseContentsFromCache(true, lang);
+    var children = ProductCategoryRepository.GetProductCategoriesByParentId(productCategoryId);
+    var childrenProducts = ProductService.GetChildrenProducts(category, children);
+
+    return new ProductCategoryViewModel
+    {
+        ProductCategoryDto = _mapper.Map<ProductCategoryDto>(category),
+        CategoryChildrenProductsDto = _mapper.Map<List<ProductDto>>(childrenProducts),
+        ProductMenuDto = _mapper.Map<MenuDto>(menus.FirstOrDefault(m => m.MenuLink.Equals("products-index", StringComparison.InvariantCultureIgnoreCase))),
+        MainPageMenuDto = _mapper.Map<MenuDto>(menus.FirstOrDefault(m => m.MenuLink.Equals("home-index", StringComparison.InvariantCultureIgnoreCase))),
+        ChildrenProductCategoriesDto = _mapper.Map<List<ProductCategoryDto>>(children),
+        BrandsDto = _mapper.Map<List<BrandDto>>(BrandService.GetBrandsIfAnyProductExists(lang)),
+        ProductCategoryTree = BuildTree(true, lang),
+        PriceFilterSettingDto = _mapper.Map<SettingDto>(SettingService.GetSettingObjectByKey(Constants.ProductPriceFilterSetting))
+    };
+}
+
+3) Updated End-User Controller example
+--------------------------------------
+public ActionResult Category(string id, int page = 1)
+{
+    var categoryId = id.GetId();
+    var vm = ProductCategoryService.GetProductCategoryForFront(categoryId);
+    if (vm == null || vm.ProductCategoryDto == null)
+    {
+        return RedirectToAction("NotFound", "Error");
+    }
+
+    vm.Page = page;
+    vm.SeoId = id;
+    return View(vm);
+}
+
+4) Minimal .cshtml illustration
+-------------------------------
+@model EImece.Domain.Models.FrontModels.ProductCategoryViewModel
+<h1>@Model.ProductCategoryDto.Name</h1>
+
+5) AutoMapper mappings
+----------------------
+CreateMap<Brand, BrandDto>();
+CreateMap<Menu, MenuDto>();
+CreateMap<Setting, SettingDto>();
+
+
+1) StoryDetailViewModel / StoryIndexViewModel (changed properties only)
+------------------------------------------------------------------------
+Before:
+public Story Story { get; set; }
+public List<StoryCategory> StoryCategories { get; set; }
+public List<Story> RelatedStories { get; set; }
+public List<Story> FeaturedStories { get; set; }
+public List<Product> RelatedProducts { get; set; }
+public Menu BlogMenu { get; set; }
+public Menu MainPageMenu { get; set; }
+public List<Tag> Tags { get; set; }
+public Story PreviousStory { get; set; }
+public Story NextStory { get; set; }
+
+public PaginatedList<Story> Stories { get; set; }
+public List<StoryCategory> StoryCategories { get; set; }
+
+After:
+public StoryDto StoryDto { get; set; }
+public List<StoryCategoryDto> StoryCategoriesDto { get; set; }
+public List<StoryDto> RelatedStoriesDto { get; set; }
+public List<StoryDto> FeaturedStoriesDto { get; set; }
+public List<ProductDto> RelatedProductsDto { get; set; }
+public MenuDto BlogMenuDto { get; set; }
+public MenuDto MainPageMenuDto { get; set; }
+public List<TagDto> TagsDto { get; set; }
+public StoryDto PreviousStoryDto { get; set; }
+public StoryDto NextStoryDto { get; set; }
+
+public PaginatedList<StoryDto> StoriesDto { get; set; }
+public List<StoryCategoryDto> StoryCategoriesDto { get; set; }
+
+2) New StoryService methods
+---------------------------
+public StoryDetailViewModel GetStoryDetailForFront(int storyId)
+{
+    var story = GetStoryById(storyId);
+    if (story == null) return null;
+
+    var language = story.Lang;
+    var tagIds = story.StoryTags?.Select(t => t.TagId).ToArray() ?? Array.Empty<int>();
+
+    var relatedStories = tagIds.Any() ? StoryRepository.GetRelatedStories(tagIds, 10, language, storyId) : new List<Story>();
+    var relatedProducts = tagIds.Any() ? ProductRepository.GetRelatedProducts(tagIds, 10, language, 0) : new List<Product>();
+
+    return new StoryDetailViewModel
+    {
+        StoryDto = _mapper.Map<StoryDto>(story),
+        StoryCategoriesDto = _mapper.Map<List<StoryCategoryDto>>(StoryCategoryService.GetActiveStoryCategories(language)),
+        RelatedStoriesDto = _mapper.Map<List<StoryDto>>(relatedStories),
+        FeaturedStoriesDto = _mapper.Map<List<StoryDto>>(StoryRepository.GetFeaturedStories(10, language, storyId)),
+        RelatedProductsDto = _mapper.Map<List<ProductDto>>(relatedProducts),
+        MainPageMenuDto = _mapper.Map<MenuDto>(MenuService.GetActiveBaseContentsFromCache(true, language)
+            .FirstOrDefault(m => m.MenuLink.Equals("home-index", StringComparison.InvariantCultureIgnoreCase))),
+        BlogMenuDto = _mapper.Map<MenuDto>(MenuService.GetActiveBaseContentsFromCache(true, language)
+            .FirstOrDefault(m => m.MenuLink.Equals("stories-categories_" + story.GetSeoUrl(), StringComparison.InvariantCultureIgnoreCase))),
+        TagsDto = _mapper.Map<List<TagDto>>(TagService.GetActiveBaseEntities(true, language)),
+        PreviousStoryDto = _mapper.Map<StoryDto>(StoryRepository.GetPreviousStory(storyId, language)),
+        NextStoryDto = _mapper.Map<StoryDto>(StoryRepository.GetNextStory(storyId, language))
+    };
+}
+
+public StoryIndexViewModel GetMainPageStoriesForFront(int page, int language)
+{
+    int pageSize = AppConfig.RecordPerPage;
+    var storiesEntity = StoryRepository.GetMainPageStories(page, pageSize, language);
+
+    var storyDtoItems = _mapper.Map<List<StoryDto>>(storiesEntity.ToList());
+    var storiesDto = new PaginatedList<StoryDto>(storyDtoItems, storiesEntity.PageIndex, storiesEntity.PageSize, storiesEntity.TotalCount);
+
+    return new StoryIndexViewModel
+    {
+        StoriesDto = storiesDto,
+        StoryCategoriesDto = _mapper.Map<List<StoryCategoryDto>>(StoryCategoryService.GetActiveStoryCategories(language))
+    };
+}
+
+3) Updated End-User Controller example
+--------------------------------------
+public ActionResult Detail(string id)
+{
+    var storyId = id.GetId();
+    var vm = StoryService.GetStoryDetailForFront(storyId);
+    if (vm == null || vm.StoryDto == null) return RedirectToAction("NotFound", "Error");
+    return View(vm);
+}
+
+public ActionResult Index(int page = 1)
+{
+    var vm = StoryService.GetMainPageStoriesForFront(page, CurrentLanguage);
+    return View(vm);
+}
+
+4) Minimal .cshtml illustration
+-------------------------------
+@model EImece.Domain.Models.FrontModels.StoryDetailViewModel
+<h1>@Model.StoryDto.Name</h1>
+
+@model EImece.Domain.Models.FrontModels.StoryIndexViewModel
+@foreach (var story in Model.StoriesDto) { <h2>@story.Name</h2> }
+
+5) AutoMapper mappings
+----------------------
+CreateMap<Story, StoryDto>();
+CreateMap<StoryCategory, StoryCategoryDto>();
+CreateMap<Tag, TagDto>();


### PR DESCRIPTION
### Motivation

- Decouple end-user Razor views from persistence entities by migrating FrontModels to rely on DTOs, reducing coupling and making the UI layer safer to refactor.  
- Provide a clear, incremental and non-breaking playbook so service-layer mapping with AutoMapper can be introduced without changing existing admin-facing entity-returning methods.

### Description

- Expanded `EImece/conversionDto.txt` into a concrete DTO refactoring blueprint that covers Product → ProductCategory → Story/Blog flows and shows Before/After FrontModel properties.  
- Added example service-layer `ForFront`/`Dto` method skeletons that call existing entity-returning methods and populate FrontModels with `_mapper.Map<...>` DTO assignments, plus corresponding controller handler snippets and minimal `.cshtml` examples.  
- Listed required AutoMapper mapping notes (new/expected maps) and emphasized the rule that all mapping stays in service layer while admin methods remain unchanged, with no runtime code paths modified in this change.

### Testing

- Validated the documentation changes and file contents by inspecting the repository using `rg`, `nl` and `sed` to view relevant FrontModels, DTOs and service classes, and confirmed the diff contains the new blueprint text.  
- No unit or integration tests were executed as part of this documentation-only change and no runtime build was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992a5a4b37083259f3293a556e181c1)